### PR TITLE
Add the ability to use SSL encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Swiftmailer version: `4.1.1`
 ## Usage:
 To enable the library add the following line at the end of `app/config/bootstrap/libraries.php`:
 
-    Libraries::add('li3_swifter');
+```php
+Libraries::add('li3_swifter');
+```
 
 From here on you can access all Swiftmailer classes and create your e-mails by yourself, read the
 Swiftmailer [docs](http://swiftmailer.org/docs/introduction.htm/), or you can use the
@@ -16,80 +18,96 @@ Swiftmailer [docs](http://swiftmailer.org/docs/introduction.htm/), or you can us
 We can add global configurations to the `Swifter` class when adding the library. It's useful
 when setting `smtp` configurations that's used in several locations.
 
-    Libraries::add('li3_swifter', array(
-        'from' => array('my@mail.tld' => 'My Name'),
-        'to' => 'foo@bar.tld', // Useful if all e-mails is for you (contact form)
-        'host' => '',
-        'port' => 25,
-        'username' => 'your_username',
-        'password' => 'your_password',
-    ));
+```php
+Libraries::add('li3_swifter', array(
+    'from' => array('my@mail.tld' => 'My Name'),
+    'to' => 'foo@bar.tld', // Useful if all e-mails is for you (contact form)
+    'host' => '',
+    'port' => 25,
+    'username' => 'your_username',
+    'password' => 'your_password',
+    'encryption' => 'ssl' // e.g if using Gmail SMTP 
+));
+```
 
 ### E-mail transports
 
-    $boolean = Swifter::mail(array $options);
-    $boolean = Swifter::smtp(array $options);
+```php
+$boolean = Swifter::mail(array $options);
+$boolean = Swifter::smtp(array $options);
+```
 
 ### Configurations
 The `$options` array supports the following items:
 
-    $options = array(
-        'from' => array('my@mail.tld' => 'My Name'),
-        'to' => array('foo@bar.tld', 'bar@foo.tld'),
-        'cc' => false,
-        'bcc' => false,
-        'subject' => '',
+```php
+$options = array(
+    'from' => array('my@mail.tld' => 'My Name'),
+    'to' => array('foo@bar.tld', 'bar@foo.tld'),
+    'cc' => false,
+    'bcc' => false,
+    'subject' => '',
+    'encryption' => 'ssl' // if needed
 
-        // Content body if not using template
-        'body' => '',
+    // Content body if not using template
+    'body' => '',
 
-        // Template to use
-        'template' => false,
+    // Template to use
+    'template' => false,
 
-        // Data to be available in the template ($subject is added automatically)
-        'data' => array(),
-    );
+    // Data to be available in the template ($subject is added automatically)
+    'data' => array(),
+);
+```
 
 If we've not set `smtp` configurations when adding the library, or need to use other configurations, we
 can add them to the `$options` array in `Swifter::smtp`.
 
-    $options = array(
-        'host' => 'smtp.example.org',
-        'port' => 25,
-        'username' => null,
-        'password' => null,
-    );
+```php
+$options = array(
+    'host' => 'smtp.example.org',
+    'port' => 25,
+    'username' => null,
+    'password' => null,
+    'encryption' => null
+);
+```
 
 ### Examples
 Quickly send an e-mail without a template:
 
-    use li3_swifter\extensions\Swifter;
+```php
+use li3_swifter\extensions\Swifter;
 
-    Swifter::smtp(array(
-        'from' => array('my@email.tld' => 'My Name'),
-        'to' => 'foo@bar',
-        'body' => 'This is the content body'
-    ));
+Swifter::smtp(array(
+    'from' => array('my@email.tld' => 'My Name'),
+    'to' => 'foo@bar',
+    'body' => 'This is the content body'
+));
+```
 
 Send a quick e-mail using a `mail` template:
+```php
+use li3_swifter\extensions\Swifter;
 
-    use li3_swifter\extensions\Swifter;
+$to = 'foo@bar';
 
-    $to = 'foo@bar';
+Swifter::smtp(array(
+    'from' => array('my@email.tld' => 'My Name'),
+    'to' => $to,
+    'template' => 'emails/welcome',
+    'data' => array('to' => $to),
+));
+```
 
-    Swifter::smtp(array(
-        'from' => array('my@email.tld' => 'My Name'),
-        'to' => $to,
-        'template' => 'emails/welcome',
-        'data' => array('to' => $to),
-    ));
-
-    // 'views/emails/welcome.mail.php'
-    <html>
-    <head>
-    <title>Welcome</title>
-    </head>
-    <body>
-        <h1>E-mail sent to: <?=$to ?></h1>
-    </body>
-    </html>
+```html
+// 'views/emails/welcome.mail.php'
+<html>
+<head>
+<title>Welcome</title>
+</head>
+<body>
+    <h1>E-mail sent to: <?=$to ?></h1>
+</body>
+</html>
+```

--- a/extensions/Swifter.php
+++ b/extensions/Swifter.php
@@ -45,6 +45,7 @@ class Swifter {
             'port' => 25,
             'username' => null,
             'password' => null,
+            'encryption' => null
         );
     }
 
@@ -60,9 +61,10 @@ class Swifter {
             'port' => static::$_config['port'],
             'username' => static::$_config['username'],
             'password' => static::$_config['password'],
+            'encryption' => static::$_config['encryption']
         );
 
-        $transport = Swift_SmtpTransport::newInstance($options['host'], $options['port'])
+        $transport = Swift_SmtpTransport::newInstance($options['host'], $options['port'], $options['encryption'])
                    ->setUsername($options['username'])
                    ->setPassword($options['password']);
 


### PR DESCRIPTION
Gmail SMTP for example requires SSL encryption. This can now be passed in with `$options`.

Also added better syntax highlighting in the README
